### PR TITLE
447: add summary text to be displayed above the sign page form and below the headline

### DIFF
--- a/research-consent-en-richtext/signing/template.yaml
+++ b/research-consent-en-richtext/signing/template.yaml
@@ -5,6 +5,16 @@ consent:
 signing:
   title: Sign Consent
   review: Review Consent
+  summary: |
+    <b>I have been informed</b> about the use of my health data and the associated risks and give my consent within the scope of what is written explained before.
+    <br><br>
+    I have had enough time to consider the information and ask questions which have been <b>answered to my satisfaction</b>.
+    <br><br>
+    I agree to the processing of my personal data by the Hasso-Plattner-Institut für Digital Engineering gGmbH, Prof.-Dr.-Helmert-Str. 2-3 14482 Potsdam, Germany (managing director: Prof. Dr. Christoph Meinel), for the purpose of providing my health data to the Smart4Health research platform.
+    <br><br>
+    I have been informed that I will <b>receive a copy</b> of the information sheet, the privacy policy, and the signed consent statement.
+    <br><br>
+    By signing this form, I am <b>consenting to providing my health data</b> to the Smart4Health research platform under the before selected conditions.
   signature:
     clear: Clear
     errors:

--- a/research-consent-en/signing/template.yaml
+++ b/research-consent-en/signing/template.yaml
@@ -5,6 +5,16 @@ consent:
 signing:
   title: Sign Consent
   review: Review Consent
+  summary: |
+    <b>I have been informed</b> about the use of my health data and the associated risks and give my consent within the scope of what is written explained before.
+    <br><br>
+    I have had enough time to consider the information and ask questions which have been <b>answered to my satisfaction</b>.
+    <br><br>
+    I agree to the processing of my personal data by the Hasso-Plattner-Institut für Digital Engineering gGmbH, Prof.-Dr.-Helmert-Str. 2-3 14482 Potsdam, Germany (managing director: Prof. Dr. Christoph Meinel), for the purpose of providing my health data to the Smart4Health research platform.
+    <br><br>
+    I have been informed that I will <b>receive a copy</b> of the information sheet, the privacy policy, and the signed consent statement.
+    <br><br>
+    By signing this form, I am <b>consenting to providing my health data</b> to the Smart4Health research platform under the before selected conditions.
   signature:
     clear: Clear
     errors:


### PR DESCRIPTION
required for [healthmetrix/dynamic-consent/pull/460](https://github.com/healthmetrix/dynamic-consent/pull/460)