### PR TITLE
448 learn more replace page with modal

### DIFF
--- a/research-consent-en/template.yaml
+++ b/research-consent-en/template.yaml
@@ -2,11 +2,12 @@
 consent:
   version: 1
   author: Smart4Health
+  descriptionModal: true
 defaults:
   navigation:
     back: BACK
     next: CONTINUE
-    learnMore: Learn More
+    learnMore: MORE DETAILS
     exit: Exit
     answer: Answer
     share: Share

--- a/research-consent-en/template.yaml
+++ b/research-consent-en/template.yaml
@@ -11,6 +11,7 @@ defaults:
     exit: Exit
     answer: Answer
     share: Share
+    close: CLOSE
 welcome:
   title: Smart4Health consent for research data provision
   image: /svgs/s4h.svg
@@ -452,7 +453,6 @@ options:
     popover: To continue, please choose option YES or NO
 
 glossary:
-  closeText: CLOSE
   items:
     - id: research
       text: "Research is creative and systematic work undertaken to increase the stock of knowledge. It involves the collection, organization and analysis of information to increase understanding of a topic or issue. A research project may be an expansion on past work in the field. To test the validity of instruments, procedures, or experiments, research may replicate elements of prior projects or the project as a whole.

--- a/research-consent-en/template.yaml
+++ b/research-consent-en/template.yaml
@@ -2,7 +2,7 @@
 consent:
   version: 1
   author: Smart4Health
-  descriptionModal: true
+  learnMoreDisplay: MODAL
 defaults:
   navigation:
     back: BACK


### PR DESCRIPTION
- move close text to general navigation for glossary
- enable viewing the "Learn More" extra page as popup modal with a displayType that can be MODAL or PAGE as fallback, or NONE if this text should be disabled no matter if there's one available or not

required for https://github.com/healthmetrix/dynamic-consent/pull/461